### PR TITLE
fix(aggregate): return default aggregate row when WHERE matches no rows

### DIFF
--- a/src/sql/executor.rs
+++ b/src/sql/executor.rs
@@ -2898,6 +2898,18 @@ impl<'a, S: RowSource> Executor<'a> for DynamicExecutor<'a, S> {
                         }
                     }
 
+                    if state.groups.is_empty()
+                        && state.group_by.is_empty()
+                        && state.group_by_exprs.is_none()
+                    {
+                        let initial_states: Vec<AggregateState> = state
+                            .aggregates
+                            .iter()
+                            .map(|_| AggregateState::new())
+                            .collect();
+                        state.groups.insert(Vec::new(), (Vec::new(), initial_states));
+                    }
+
                     let results: Vec<(Vec<Value<'static>>, Vec<AggregateState>)> =
                         state.groups.drain().map(|(_, v)| v).collect();
                     state.result_iter = Some(results.into_iter());

--- a/tests/regression_smoke_test.rs
+++ b/tests/regression_smoke_test.rs
@@ -1060,6 +1060,25 @@ mod edge_cases {
     }
 
     #[test]
+    fn count_with_where_matching_no_rows_returns_one_row_with_zero() {
+        let (db, _dir) = create_test_db();
+
+        db.execute("CREATE TABLE count_test (id INTEGER PRIMARY KEY, status TEXT)")
+            .unwrap();
+        db.execute("INSERT INTO count_test VALUES (1, 'active')").unwrap();
+        db.execute("INSERT INTO count_test VALUES (2, 'active')").unwrap();
+
+        let rows = db
+            .query("SELECT COUNT(*) as cnt FROM count_test WHERE status = 'nonexistent'")
+            .unwrap();
+        assert_eq!(rows.len(), 1, "COUNT with WHERE matching no rows should return 1 row");
+        match &rows[0].values[0] {
+            OwnedValue::Int(v) => assert_eq!(*v, 0, "COUNT should be 0 when no rows match"),
+            other => panic!("Expected Int(0), got {:?}", other),
+        }
+    }
+
+    #[test]
     fn null_handling() {
         let (db, _dir) = create_test_db();
 


### PR DESCRIPTION
## Summary
- Fixed aggregate queries returning 0 rows when WHERE clause matches no rows
- Added check in `DynamicExecutor::HashAggregate` to create default aggregate group when no rows match and no GROUP BY exists

## Test plan
- [x] New test `count_with_where_matching_no_rows_returns_one_row_with_zero` added
- [x] Original failing test `delete_with_complex_where_clause` now passes
- [x] Pre-commit hooks pass (clippy, safety comments)

Fixes https://github.com/kahflane/TurDB/issues/30

🤖 Generated with [Claude Code](https://claude.ai/code)