### PR TITLE
fix(constraint): handle compound CHECK expressions with AND/OR operators

### DIFF
--- a/src/database/convert.rs
+++ b/src/database/convert.rs
@@ -204,7 +204,7 @@ impl Database {
     }
 
     pub(crate) fn expr_to_string(expr: &crate::sql::ast::Expr<'_>) -> Option<String> {
-        use crate::sql::ast::{BinaryOperator, Expr};
+        use crate::sql::ast::{BinaryOperator, Expr, UnaryOperator};
 
         match expr {
             Expr::BinaryOp { left, op, right } => {
@@ -227,6 +227,16 @@ impl Database {
                     _ => "?",
                 };
                 Some(format!("{} {} {}", left_str, op_str, right_str))
+            }
+            Expr::UnaryOp { op, expr: inner } => {
+                let inner_str = Self::expr_to_string(inner)?;
+                let op_str = match op {
+                    UnaryOperator::Minus => "-",
+                    UnaryOperator::Plus => "+",
+                    UnaryOperator::Not => "NOT ",
+                    UnaryOperator::BitwiseNot => "~",
+                };
+                Some(format!("{}{}", op_str, inner_str))
             }
             Expr::Column(col_ref) => Some(col_ref.column.to_string()),
             Expr::Literal(lit) => match lit {

--- a/src/database/dml/insert.rs
+++ b/src/database/dml/insert.rs
@@ -567,7 +567,7 @@ impl Database {
                 for constraint in col.constraints() {
                     if let Constraint::Check(expr_str) = constraint {
                         let col_value = values.get(col_idx);
-                        if !Database::evaluate_check_expression(expr_str, col.name(), col_value) {
+                        if !Database::evaluate_check_expression(expr_str, col.name(), col_value)? {
                             bail!(
                                 "CHECK constraint violated on column '{}' in table '{}': {}",
                                 col.name(),

--- a/src/database/dml/update.rs
+++ b/src/database/dml/update.rs
@@ -490,7 +490,7 @@ impl Database {
                                         expr_str,
                                         col.name(),
                                         col_value,
-                                    ) {
+                                    )? {
                                         bail!(
                                             "CHECK constraint violated on column '{}' in table '{}': {}",
                                             col.name(),
@@ -649,7 +649,7 @@ impl Database {
                         for constraint in col.constraints() {
                             if let Constraint::Check(expr_str) = constraint {
                                 let col_value = row_values.get(col_idx);
-                                if !Self::evaluate_check_expression(expr_str, col.name(), col_value)
+                                if !Self::evaluate_check_expression(expr_str, col.name(), col_value)?
                                 {
                                     bail!(
                                         "CHECK constraint violated on column '{}' in table '{}': {}",
@@ -1369,7 +1369,7 @@ impl Database {
                         for constraint in col.constraints() {
                             if let Constraint::Check(expr_str) = constraint {
                                 let col_value = row_values.get(col_idx);
-                                if !Self::evaluate_check_expression(expr_str, col.name(), col_value)
+                                if !Self::evaluate_check_expression(expr_str, col.name(), col_value)?
                                 {
                                     bail!(
                                         "CHECK constraint violated on column '{}' in table '{}': {}",


### PR DESCRIPTION
## Summary

- Fixes the CHECK constraint evaluator to properly handle compound expressions with AND/OR operators
- Previously, `CHECK (age >= 0 AND age <= 150)` would not reject invalid values like `-5`
- Now recursively evaluates AND/OR expressions, respecting parenthesis nesting
- Properly extracts numeric operands without including trailing operators

## Root Cause

The naive string parsing found the first comparison operator (e.g., `>=`) and tried to parse everything after it as a number. For `age >= 0 AND age <= 150`, this meant parsing `"0 AND age <= 150"` as a number, which failed and defaulted to returning `true`.

## Solution

- Check for AND/OR at the top level (respecting parentheses depth)
- Split and recursively evaluate each part
- For simple comparisons, extract only numeric characters from operands

## Test plan

- [x] `check_constraint_violation_returns_error` now passes (was failing)
- [x] All existing CHECK constraint tests still pass (10 tests)
- [x] Full test suite passes
- [x] Clippy clean

Fixes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)